### PR TITLE
Deploy Docker image to GitHub Packages

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,28 @@
+name: Publish Docker image to GitHub Packages
+
+on:
+  push:
+    branches: [ main]
+
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}/image-name:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Start from a Python base image
+FROM python:3.8-slim-buster
+
+# Update the package lists
+RUN apt-get update
+
+# Install necessary packages for PostgreSQL and GDAL
+RUN apt-get install -y libpq-dev python3-dev libgdal-dev
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install Python packages
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY src/ .
+
+# Command to run on container start
+CMD [ "/bin/bash" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+geopandas==0.9.0
+sqlalchemy==1.4.15
+psycopg2-binary==2.8.6


### PR DESCRIPTION
This pull request adds the necessary files to deploy a Docker image to GitHub Packages. The Docker image includes Python 3.8, PostgreSQL and GDAL dependencies, as well as the necessary Python packages specified in the requirements.txt file. The Docker image is built and pushed to the ghcr.io registry upon push to the main branch. This will allow for easy deployment of the application in a containerized environment.