### PR TITLE
Update Docker Hub login and image tags

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -13,16 +13,15 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Log in to GitHub Docker Registry
+      - name: Log in to Docker Hub
         uses: docker/login-action@v1 
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}/image-name:latest
+          tags: lacmta/geodb-base:latest


### PR DESCRIPTION
This pull request updates the Docker Hub login credentials and image tags used in the build and push process. The `ghcr.io` registry is replaced with `lacmta/geodb-base` and the GitHub token is replaced with the Docker Hub username and token stored in secrets. This ensures that the Docker image is built and pushed to the correct repository with the correct credentials.