### PR TITLE
Update GeoDB Docker image documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ To use this image, you can use the following Dockerfile:
 FROM lacmta/geodb-base:latest
 ```
 
+You can also pull the image directly from Docker Hub and run it:
+
+```bash
+docker run -it lacmta/geodb-base:latest
+```
+
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# geodb-image
+# GeoDB Base Docker Image
+
+Welcome to the geodb docker image repostory.
+
+The Docker image can be found at [Docker Hub](https://hub.docker.com/r/lacmta/geodb-base).
+
+ This image is based on the official python:3.8-slim-buster image and with the following libraries installed:
+
+- gdal
+- geopandas
+- pandas
+- postgresql
+- psycopg2
+- sqlalchemy
+
+It is intended to be used as a base image for other images that need to use the above libraries.
+
+## Versions
+
+Currently following versions are available:
+- base: latest
+
+This is the base image for all other images. It contains the above libraries for Python 3.8.
+
+## Usage
+
+To use this image, you can use the following Dockerfile:
+
+```dockerfile
+FROM lacmta/geodb-base:latest
+```
+


### PR DESCRIPTION


## Change log
- This pull request updates the documentation for the GeoDB Docker image repository. 
- No issues are fixed in this pull request.

### Info
It includes a more detailed description of the image, the libraries installed, and how to use it. The Docker image is based on the official python:3.8-slim-buster image and includes libraries such as gdal, geopandas, pandas, postgresql, psycopg2, and sqlalchemy. This update is intended to make it easier for users to understand and use the image as a base for other images.

